### PR TITLE
Adds OSGi Manifest Headers using OSGi plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'maven'
 apply plugin: 'osgi'
 
 group = 'com.liferay.mobile'
-version = '1.0-SNAPSHOT'
+version = '1.1-SNAPSHOT'
 description = "Liferay Camel Component"
 
 sourceCompatibility = 1.6
@@ -43,7 +43,6 @@ jar {
     manifest {
         instruction 'Export-Package', 'com.liferay.mobile.camel'
         instruction 'Bundle-Vendor', 'Liferay Inc.'
-        instruction 'Bundle-Description', 'A Camel Component for Liferay\'s Message Bus'
         instruction 'Export-Service', 'org.apache.camel.spi.ComponentResolver;component=liferay'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'java'
 apply plugin: 'maven'
+apply plugin: 'osgi'
 
 group = 'com.liferay.mobile'
 version = '1.0-SNAPSHOT'
@@ -36,6 +37,15 @@ dependencies {
 	testCompile group: 'log4j', name: 'log4j', version:'1.2.16'
 	testCompile group: 'org.apache.camel', name: 'camel-test', version:'2.9.0'
 	testCompile group: 'org.slf4j', name: 'slf4j-log4j12', version:'1.6.1'
+}
+
+jar {
+    manifest {
+        instruction 'Export-Package', 'com.liferay.mobile.camel'
+        instruction 'Bundle-Vendor', 'Liferay Inc.'
+        instruction 'Bundle-Description', 'A Camel Component for Liferay\'s Message Bus'
+        instruction 'Export-Service', 'org.apache.camel.spi.ComponentResolver;component=liferay'
+    }
 }
 
 task format(type: JavaExec) {

--- a/src/main/java/com/liferay/mobile/camel/LiferayConsumer.java
+++ b/src/main/java/com/liferay/mobile/camel/LiferayConsumer.java
@@ -50,6 +50,7 @@ public class LiferayConsumer extends DefaultConsumer
 		}
 
 		exchange.getIn().setBody(payload);
+		exchange.getIn().setHeader("liferay-ResponseId", message.getResponseId());
 
 		try {
 			getProcessor().process(exchange);

--- a/src/main/java/com/liferay/mobile/camel/LiferayProducer.java
+++ b/src/main/java/com/liferay/mobile/camel/LiferayProducer.java
@@ -50,6 +50,11 @@ public class LiferayProducer extends DefaultProducer {
 		Message message = new Message();
 		message.setPayload(payload);
 
+		String responseId = (String) exchange.getIn().getHeader("liferay-ResponseId");
+		if (responseId != null) {
+			message.setResponseId(responseId);
+		}
+
 		messageBus.sendMessage(destinationName, message);
 	}
 


### PR DESCRIPTION
This (unsolicited :smile:) PR uses the default Gradle `osgi` plugin to add the Manifest headers in order to make the component OSGi-aware, using the same mechanism (The `Export-Service` header) that the Camel core components and the official Maven Archetype for Camel Components.

I'm currently using it this way in a Blueprint setting (LR 6.2/Aries) which makes for very convenient Route deployment.
